### PR TITLE
[WIP] Set priority of layers to 12

### DIFF
--- a/meta-xt-prod-aos-rcar-dom0/conf/layer.conf
+++ b/meta-xt-prod-aos-rcar-dom0/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-prod-aos-rcar-dom0"
 BBFILE_PATTERN_xt-prod-aos-rcar-dom0 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-prod-aos-rcar-dom0 = "7"
+BBFILE_PRIORITY_xt-prod-aos-rcar-dom0 = "12"
 
 LAYERSERIES_COMPAT_xt-prod-aos-rcar-dom0 = "dunfell"
 

--- a/meta-xt-prod-aos-rcar-domd/conf/layer.conf
+++ b/meta-xt-prod-aos-rcar-domd/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-prod-aos-domd"
 BBFILE_PATTERN_xt-prod-aos-domd := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-prod-aos-domd = "7"
+BBFILE_PRIORITY_xt-prod-aos-domd = "12"
 
 LAYERSERIES_COMPAT_xt-prod-aos-domd = "dunfell"
 

--- a/meta-xt-prod-aos-rcar-domf/conf/layer.conf
+++ b/meta-xt-prod-aos-rcar-domf/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-prod-aos-domf"
 BBFILE_PATTERN_xt-prod-aos-domf := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-prod-aos-domf = "7"
+BBFILE_PRIORITY_xt-prod-aos-domf = "12"
 
 LAYERSERIES_COMPAT_xt-prod-aos-domf = "dunfell"
 

--- a/meta-xt-prod-aos-rcar-domx/conf/layer.conf
+++ b/meta-xt-prod-aos-rcar-domx/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-prod-aos-domx"
 BBFILE_PATTERN_xt-prod-aos-domx := "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-prod-aos-domx = "7"
+BBFILE_PRIORITY_xt-prod-aos-domx = "12"
 
 LAYERSERIES_COMPAT_xt-prod-aos-domx = "dunfell"
 


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-xt-<product>  - 12
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>