### PR TITLE
yaml: remove | from BBMASK

### DIFF
--- a/prod-aos-rcar.yaml
+++ b/prod-aos-rcar.yaml
@@ -392,7 +392,7 @@ parameters:
                 - "../meta-xt-rcar/meta-xt-cogent-fixups"
               conf:
                 # Ignore OP-TEE patches as we have own OP-TEE
-                - [BBMASK_append, "|meta-rcar-gen3-adas/recipes-bsp/optee"]
+                - [BBMASK_append, " meta-rcar-gen3-adas/recipes-bsp/optee"]
 
     m3ulcb:
       overrides:


### PR DESCRIPTION
Note: this commit is adopted from meta-xt-prod-devel with all signatures.

BBMASK is space separated list of regular expressions. So it's possible to use `|`, but space is more proper separator. Also spaces increase readability.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>
Acked-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>