### PR TITLE
[Workaround] Use meta-oe-fixups to solve srecord issue

### DIFF
--- a/prod-aos-rcar.yaml
+++ b/prod-aos-rcar.yaml
@@ -211,6 +211,7 @@ components:
         - "../meta-openembedded/meta-filesystems"
         - "../meta-xt-common/meta-xt-domx"
         - "../meta-xt-common/meta-xt-driver-domain"
+        - "../meta-xt-rcar/meta-oe-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-fixups"
         - "../meta-xt-rcar/meta-xt-rcar-driver-domain"
         - "../meta-xt-rcar/meta-xt-rcar-domx"


### PR DESCRIPTION
Note: this commit is cherry-picked from
meta-xt-prod-devel-rcar with all signatures.
---

Add layer with workaround for incorrect libc
used by srec_cat.
See comments inside `meta-oe-fixups` for details.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>
Reviewed-by: Volodymyr Babchuk <volodymyr_babcbuk@epam.com>